### PR TITLE
[PLATI-145] Increment spy gem, get rid of BigDecimal.new

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ gemspec
 gem 'stackprof', platforms: :mri_21
 
 group :test do
-  gem 'spy', '0.4.1'
+  gem 'spy', '0.4.5'
   gem 'benchmark-ips'
 end

--- a/lib/liquid/standardfilters.rb
+++ b/lib/liquid/standardfilters.rb
@@ -293,11 +293,11 @@ module Liquid
     def to_number(obj)
       case obj
       when Float
-        BigDecimal.new(obj.to_s)
+        BigDecimal(obj.to_s)
       when Numeric
         obj
       when String
-        (obj.strip =~ /\A\d+\.\d+\z/) ? BigDecimal.new(obj) : obj.to_i
+        (obj.strip =~ /\A\d+\.\d+\z/) ? BigDecimal(obj) : obj.to_i
       else
         0
       end

--- a/test/integration/drop_test.rb
+++ b/test/integration/drop_test.rb
@@ -113,6 +113,7 @@ class DropsTest < Minitest::Test
   end
 
   def test_rendering_raises_on_tainted_attr
+    skip "taint mode deprecated"
     with_taint_mode(:error) do
       tpl = Liquid::Template.parse('{{ product.user_input }}')
       assert_raises TaintedError do
@@ -122,6 +123,7 @@ class DropsTest < Minitest::Test
   end
 
   def test_rendering_warns_on_tainted_attr
+    skip "taint mode deprecated"
     with_taint_mode(:warn) do
       tpl = Liquid::Template.parse('{{ product.user_input }}')
       tpl.render!('product' => ProductDrop.new)


### PR DESCRIPTION
This PR removes the use of `BigDecimal.new` from `liquid 3.0.6` 

A new branch has been created for Brazes' fork called `3-0-stable-braze` and this PR merges into that branch. 

The `spy` gem was also updated in order to get tests running to confirm the fix. 2 tests have been skipped related to tainted input, which has been deprecated and removed from Ruby >=2.7. 

[PLATI-145](https://jira.braze.com/browse/PLATI-145)